### PR TITLE
Fix not returning the video with added noise

### DIFF
--- a/tutorials/tutorial12/tutorial-12-cdmd.py
+++ b/tutorials/tutorial12/tutorial-12-cdmd.py
@@ -121,7 +121,7 @@ def get_video_dmd(
     if noise:
         vid += np.random.normal(0, noise_amt, vid.shape)
         vid = vid.clip(0, 1)
-    return np.vstack(imgs).T, shape
+    return vid, shape
 
 
 def get_video(object: str = "frog") -> np.ndarray:


### PR DESCRIPTION
There's an option to add the noise to the original frames. However, after adding gaussian noise, the function returns the original frames.