### PR TITLE
Fix plot_summary() method for 2D snapshots to correctly reshape into original snapshots dimensions

### DIFF
--- a/pydmd/plotter.py
+++ b/pydmd/plotter.py
@@ -899,7 +899,7 @@ def plot_summary(
     if len(snapshots_shape) == 2:
         if y is None:
             y = np.arange(snapshots_shape[1])
-        ygrid, xgrid = np.meshgrid(y, x)
+        xgrid, ygrid = np.meshgrid(x, y)
 
     # PLOTS 4-6: Plot the DMD modes.
     for i, (ax, idx) in enumerate(zip(mode_axes, index_modes)):
@@ -913,7 +913,7 @@ def plot_summary(
             ax.plot(x, lead_modes[:, idx].real, c=mode_color)
         else:
             # Plot modes in 2-D.
-            mode = lead_modes[:, idx].reshape(*snapshots_shape, order=order)
+            mode = lead_modes[:, idx].reshape(xgrid.shape, order=order)
             vmax = np.abs(mode.real).max()
             im = ax.pcolormesh(
                 xgrid,


### PR DESCRIPTION
Official documentation says that `snapshots_shape `parameter is supposed to be: **(width, height).**

Taking that into account, plotting of the 2D modes inside `plot_summary()` method was wrong.
I will explain it using my use-case. I am using DMD for background extraction. 

1. These are my original snapshots (320x240 images, where width=320) plotted using `plotter.plot_snapshots_2D` method
![original_snapshots](https://github.com/karlic-luka/PyDMD/assets/73157092/244d6d79-32b3-4cc0-bcbd-901003a19949)

2. Modes using `plotter.plot_summary()`are complete "junk"- they aren't explainable at all (however, dimensions are right - 320x240, where width is 320)
![modes_original_method](https://github.com/karlic-luka/PyDMD/assets/73157092/65887ef2-b33a-49f7-99e1-534891e16839)

3. Modes using fixed `plotter.plot_summary()` from my local PyDMD library
![image](https://github.com/karlic-luka/PyDMD/assets/73157092/5ab7f08d-c3bd-4d7a-9181-b7a229d68e74)

We can see that now modes are explainable - i.e. first mode is actually a background, other modes are some other features.

The problem occurred during reshaping of snapshots into original shape because it was done _column-wise_ instead of _row-wise_. Order was default (C-style), but we were actually doing F-style ordering.


P.S. methods `plotter.plot_modes_2D` and `plotter.plot_snapshots_2D` are doing the similar thing, but they are correctly taking into account that provided parameter `snapshots_shape` is **(width, height)**, not **(height, width)** and they are not using `snapshots_shape` parameter to reshape.

P.P.S. I used the exact same approach from those 2 methods to fix this one